### PR TITLE
add Docker and Make build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 *.so
 venv
 dist
+docker/boost_*

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,29 @@
 
-all: test
+SETUP_FLAGS = G_SPEAK_HOME=/usr APPLY_LP2002043_UBUNTU_CFLAGS_WORKAROUND=1
+BOOST_SRC = "docker/boost_1_49_0.tar.gz"
+BOOST_URL = "http://sourceforge.net/projects/boost/files/boost/1.49.0/boost_1_49_0.tar.gz"
 
-.PHONY: test
+.PHONY: test shell
+
+all: test-docker
+
+test-docker: docker
+	docker run -ti --rm -v $$PWD:/work -w /work cplasma /bin/bash -c 'make test'
 
 test:
-	python setup.py build_ext --inplace
+	${SETUP_FLAGS} python setup.py build_ext --inplace
 	python test/yamlio_test.py
 	python test/pool_server_test.py
 	python test/unicode_test.py
 	python test/hash_test.py
 	python test/test_readable_slaw.py
 
+shell: docker
+	docker run --name cplasma-shell -ti --rm -v $$PWD:/work -w /work cplasma /bin/bash
+
+docker: docker/Dockerfile ${BOOST_SRC}
+	docker build -f docker/Dockerfile docker/ -t cplasma
+
+# Download Boost from this link https://www.boost.org/users/history/version_1_49_0.html
+${BOOST_SRC}:
+	test -f $@ || wget ${BOOST_URL} -O ${BOOST_SRC}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM plasma
+
+RUN add-apt-repository ppa:deadsnakes/ppa && apt-get update
+RUN apt-get install -y \
+    python2.7 \
+    python2.7-dev \
+    python-pip
+
+RUN pip2 install wheel
+RUN pip2 install numpy
+
+RUN ln -s /usr/bin/python2.7 /usr/bin/python
+
+COPY boost_1_49_0.tar.gz install_boost.sh /opt/boost/
+WORKDIR /opt/boost/
+RUN ./install_boost.sh

--- a/docker/install_boost.sh
+++ b/docker/install_boost.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+BOOST_VER=1.49.0
+BOOST_DIR="boost_${BOOST_VER//./_}"
+
+if ! [ -d "$BOOST_DIR" ]; then
+    tar -xf "$BOOST_DIR.tar.gz"
+fi
+cd "$BOOST_DIR"
+./bootstrap.sh --with-libraries=python
+
+cat <<JAM > py27-config.jam
+# Specify Python configuration
+using python 
+    : 2.7                       # Version of Python
+    : /usr/bin/python2.7        # Path to the Python interpreter
+    : /usr/include/python2.7    # Path to the Python headers
+    : /usr/lib/x86_64-linux-gnu # Path to the Python libraries
+    : <python-debugging>off     # No debugging symbols
+    : <cxxflags>-std=c++11
+    ;
+JAM
+
+# Install python boost library
+sudo ./b2 install --with-python -sNO_BZIP2=1 --prefix=/usr --user-config=py27-config.jam -j$(nproc)


### PR DESCRIPTION
With the plasma image in zeugma-hamper/plasma#3, we can use a similar Docker and Make build to build the Python 2.7 bindings:

    make

The built image can be entered with:

    make shell